### PR TITLE
Refactor the project root management

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,4 +1,3 @@
 export YOUR_TRAIN_DATASET_PATH="/your/project/root/data/blues/train"
 export YOUR_VAL_DATASET_PATH="/your/project/root/data/blues/val"
 export YOUR_TEST_DATASET_PATH="/your/project/root/data/blues/test"
-export PROJECT_ROOT="/my/abolute/path"

--- a/src/nn_template/common/utils.py
+++ b/src/nn_template/common/utils.py
@@ -89,7 +89,7 @@ load_envs()
 try:
     PROJECT_ROOT = Path(git.Repo(Path.cwd(), search_parent_directories=True).working_dir)
 except git.exc.InvalidGitRepositoryError:
-    PROJECT_ROOT = Path(Path.cwd())
+    PROJECT_ROOT = Path.cwd()
 
 logger.debug(f"Inferred project root: {PROJECT_ROOT}")
 os.environ["PROJECT_ROOT"] = str(PROJECT_ROOT)

--- a/src/nn_template/common/utils.py
+++ b/src/nn_template/common/utils.py
@@ -1,10 +1,14 @@
+import logging
 import os
 from pathlib import Path
 from typing import Optional
 
 import dotenv
+import git
 import pytorch_lightning as pl
 from omegaconf import DictConfig, OmegaConf
+
+logger = logging.getLogger(__name__)
 
 
 def get_env(env_name: str, default: Optional[str] = None) -> str:
@@ -82,10 +86,12 @@ def log_hyperparameters(
 # Load environment variables
 load_envs()
 
-# Set the cwd to the project root
-PROJECT_ROOT: Path = Path(get_env("PROJECT_ROOT"))
-assert PROJECT_ROOT.exists(), "You must configure the PROJECT_ROOT environment variable in a .env file!"
+try:
+    PROJECT_ROOT = Path(git.Repo(Path.cwd(), search_parent_directories=True).working_dir)
+except git.exc.InvalidGitRepositoryError:
+    PROJECT_ROOT = Path(Path.cwd())
 
-os.chdir(PROJECT_ROOT)
+logger.debug(f"Inferred project root: {PROJECT_ROOT}")
+os.environ["PROJECT_ROOT"] = str(PROJECT_ROOT)
 
 Split = str


### PR DESCRIPTION
This PR:

- Removes the `PROJECT_ROOT` environment variable, which was a pain to configure each time
- Infers the `PROJECT_ROOT` from the git repository, if it is not a git repository it fallbacks to the current working directory
- Changes the behaviour to not change the cwd to the project root

---

- On hold until #11 is merged
- [x] Rebase onto develop