### PR TITLE
Overwrite Lightning logging configuration

### DIFF
--- a/src/nn_template/__init__.py
+++ b/src/nn_template/__init__.py
@@ -2,6 +2,18 @@ import logging
 
 from nn_core.console_logging import NNRichHandler
 
+# Required workaround because PyTorch Lightning configures the logging on import,
+# thus the logging configuration defined in the __init__.py must be called before
+# the lightning import otherwise it has no effect.
+# See https://github.com/PyTorchLightning/pytorch-lightning/issues/1503
+#
+# Force the execution of __init__.py if this file is executed directly.
+lightning_logger = logging.getLogger("pytorch_lightning")
+# Remove all handlers associated with the lightning logger.
+for handler in lightning_logger.handlers[:]:
+    lightning_logger.removeHandler(handler)
+lightning_logger.propagate = True
+
 FORMAT = "%(message)s"
 logging.basicConfig(
     format=FORMAT,

--- a/src/nn_template/run.py
+++ b/src/nn_template/run.py
@@ -1,11 +1,3 @@
-# Required workaround because PyTorch Lightning configures the logging on import,
-# thus the logging configuration defined in the __init__.py must be called before
-# the lightning import otherwise it has no effect.
-# See https://github.com/PyTorchLightning/pytorch-lightning/issues/1503
-#
-# Force the execution of __init__.py if this file is executed directly.
-import nn_template  # isort:skip # noqa
-
 import logging
 from operator import xor
 from typing import List, Optional, Tuple
@@ -22,7 +14,6 @@ from nn_core.model_logging import NNLogger
 from nn_core.resume import resolve_ckpt, resolve_run_path, resolve_run_version
 
 pylogger = logging.getLogger(__name__)
-
 
 RESUME_MODES = {
     "continue": {


### PR DESCRIPTION
This avoids the need to import `nn_template` before lightning to format also the lightning logs