### PR TITLE
Introduce the seed index concept

### DIFF
--- a/conf/train/default.yaml
+++ b/conf/train/default.yaml
@@ -1,6 +1,6 @@
 # reproducibility
+seed_index: 0
 deterministic: False
-random_seed: 42
 
 # PyTorch Lightning Trainer https://pytorch-lightning.readthedocs.io/en/stable/common/trainer.html
 trainer:

--- a/src/nn_template/run.py
+++ b/src/nn_template/run.py
@@ -3,6 +3,7 @@ from operator import xor
 from typing import List, Optional, Tuple
 
 import hydra
+import numpy as np
 import omegaconf
 import pytorch_lightning as pl
 from hydra.core.hydra_config import HydraConfig
@@ -96,8 +97,15 @@ def run(cfg: DictConfig) -> str:
 
     :param cfg: run configuration, defined by Hydra in /conf
     """
-    if cfg.train.deterministic:
-        seed_everything(cfg.train.random_seed)
+    if "seed_index" in cfg.train and cfg.train.seed_index is not None:
+        seed_index = cfg.train.seed_index
+        seed_everything(42)
+        seeds = np.random.randint(np.iinfo(np.int32).max, size=max(42, seed_index + 1))
+        seed = seeds[seed_index]
+        seed_everything(seed)
+        pylogger.info(f"Setting seed {seed} from seeds[{seed_index}]")
+    else:
+        pylogger.warning("The seed has not been set! The reproducibility is not guaranteed.")
 
     fast_dev_run: bool = cfg.train.trainer.fast_dev_run
     if fast_dev_run:


### PR DESCRIPTION
The user does not specify a seed, but and index over a pre-defined
list of seeds. This allows to easily run multiple time the same
experiment with the different seeds:

The following will run the same experiment with five different
random seeds:
```python
python run.py -m train.seed_index=1,2,3,4,5
```